### PR TITLE
m_overridePlayerVersion のような0詰めの値を加算する場合は明示的に10進数と指定する

### DIFF
--- a/.github/workflows/bump_up_asset_version.sh
+++ b/.github/workflows/bump_up_asset_version.sh
@@ -10,7 +10,7 @@ update_addressables() {
   if [ -f "Assets/AddressableAssetsData/AddressableAssetSettings.asset" ]; then
     file_name="Assets/AddressableAssetsData/AddressableAssetSettings.asset"
     current_version=$(< $file_name grep "m_overridePlayerVersion" | awk '{print $2}')
-    next_version=$(printf "%0${#current_version}d" $((current_version + 1)))
+    next_version=$(printf "%0${#current_version}d" $((10#current_version + 1)))
     sed -i "s/m_overridePlayerVersion: $current_version/m_overridePlayerVersion: $next_version/" "$file_name"
 
     echo -e "* \`$file_name\`: $current_version => $next_version" >> message

--- a/.github/workflows/bump_up_asset_version.sh
+++ b/.github/workflows/bump_up_asset_version.sh
@@ -10,7 +10,7 @@ update_addressables() {
   if [ -f "Assets/AddressableAssetsData/AddressableAssetSettings.asset" ]; then
     file_name="Assets/AddressableAssetsData/AddressableAssetSettings.asset"
     current_version=$(< $file_name grep "m_overridePlayerVersion" | awk '{print $2}')
-    next_version=$(printf "%0${#current_version}d" $((10#current_version + 1)))
+    next_version=$(printf "%0${#current_version}d" $((10#$current_version + 1)))
     sed -i "s/m_overridePlayerVersion: $current_version/m_overridePlayerVersion: $next_version/" "$file_name"
 
     echo -e "* \`$file_name\`: $current_version => $next_version" >> message


### PR DESCRIPTION
# 何が起きていたか
パビリオン内GitHubActions 「手動 Assetバージョン更新」実行時
![image](https://github.com/user-attachments/assets/f5b4f5eb-f9b1-4dec-88de-c1de721477c8)

m_overridePlayerVersion が Increase されず Decrease されるケースがあった
![image](https://github.com/user-attachments/assets/932901fe-863b-4152-a0e8-5a9a8835d7d9)

# 何が原因か
ShellScript において0詰の数値は「8進数」として取り扱われる
https://totech.hateblo.jp/entry/2014/12/05/082807

```
#!/bin/sh

current=00001
next=$(printf "%0${#current}d" $(($current + 1)))
echo $next  # 期待する結果: 00002

current=00008
next=$(printf "%0${#current}d" $(($current + 1)))
echo $next  # 期待する結果: 00009

current=00009
next=$(printf "%0${#current}d" $(($current + 1)))
echo $next  # 期待する結果: 00010

current=00012
next=$(printf "%0${#current}d" $(($current + 1)))
echo $next  # 期待する結果: 00013
```

このようなシェルスクリプトを実行すると、以下のような結果となる
![image (1)](https://github.com/user-attachments/assets/4709d507-9419-4169-b63c-9d57c2e08c1c)

* 00008 や 00009 のケースは例外を返す
* 00012の場合、10進数だと 10 と解釈され、そこから+1 された11を返す

# どのように対処したか
current_versionの前に 10# を付けることで 10進数として解釈させる

```
#!/bin/sh

current=00001
next=$(printf "%0${#current}d" $((10#$current + 1)))
echo $next  # 期待する結果: 00002

current=00008
next=$(printf "%0${#current}d" $((10#$current + 1)))
echo $next  # 期待する結果: 00009

current=00009
next=$(printf "%0${#current}d" $((10#$current + 1)))
echo $next  # 期待する結果: 00010

current=00012
next=$(printf "%0${#current}d" $((10#$current + 1)))
echo $next  # 期待する結果: 00013
```

![image (2)](https://github.com/user-attachments/assets/e03cef8b-e942-4c87-944b-7a3b8eb6b3de)

